### PR TITLE
fix: chunk size

### DIFF
--- a/cmd/lambda/download.go
+++ b/cmd/lambda/download.go
@@ -26,7 +26,7 @@ func handleDownload(ctx context.Context, input *efsu.Input) (*efsu.Output, error
 		fRange.Size = info.Size()
 	}
 
-	var limit int64 = 5e6
+	var limit int64 = 4e6
 	if fRange.Size > limit {
 		fRange.Size = limit
 	}

--- a/cmd/lambda/download.go
+++ b/cmd/lambda/download.go
@@ -45,6 +45,8 @@ func handleDownload(ctx context.Context, input *efsu.Input) (*efsu.Output, error
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	
+	fmt.Printf("cp fileSize=%d offset=%d rangeLen=%d read=%d\n", info.Size(), fRange.Offset, fRange.Size, copied)
 
 	if copied != fRange.Size {
 		return nil, errors.New("too little data read")

--- a/cmd/lambda/download.go
+++ b/cmd/lambda/download.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"io"
 	"os"
+	"fmt"
 )
 
 func handleDownload(ctx context.Context, input *efsu.Input) (*efsu.Output, error) {


### PR DESCRIPTION
A limit of 5MB raw bytes is too high as it becomes 6.67MB after base64-encoding - which is greater than the Lambda payload limit of 6MB.